### PR TITLE
Update Dockerfile

### DIFF
--- a/service2/Dockerfile
+++ b/service2/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . /app
 
-RUN pip install --no-cache-dir fastapi uvicorn redis requests openai
+RUN pip install --no-cache-dir fastapi uvicorn redis requests openai tiktoken
 
 EXPOSE 80
 


### PR DESCRIPTION
package tiktoken was missing and caused this error.

service3-1  | ImportError: Could not import tiktoken python package. This is needed in order to for OpenAIEmbeddings. Please install it with `pip install tiktoken`.