### PR TITLE
Update Dockerfile

### DIFF
--- a/service3/Dockerfile
+++ b/service3/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . /app
 
-RUN pip install --no-cache-dir fastapi uvicorn redis requests openai langchain python-dotenv postgres psycopg2-binary pgvector
+RUN pip install --no-cache-dir fastapi uvicorn redis requests openai langchain python-dotenv postgres psycopg2-binary pgvector tiktoken
 
 # install postgresql client
 RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
similar to service2, this missing package throws an error on run

service3-1  | ImportError: Could not import tiktoken python package. This is needed in order to for OpenAIEmbeddings. Please install it with `pip install tiktoken`.